### PR TITLE
Avoid finding empty exercise files when selecting random exercise

### DIFF
--- a/cmd/root/sweet.go
+++ b/cmd/root/sweet.go
@@ -457,7 +457,8 @@ func fromArgs(cmd *cobra.Command, args []string) (exercise Exercise, err error) 
 			if language != "" {
 				err = errors.New("failed to find exercise matching language " + language)
 			} else {
-				err = errors.New("no files in the exercises directory")
+				msg := fmt.Sprintf("no exercises found in the following exercise directory: %s\n", exercisesDir)
+				err = errors.New(msg)
 			}
 			return
 		}
@@ -475,11 +476,14 @@ func fromArgs(cmd *cobra.Command, args []string) (exercise Exercise, err error) 
 			// if text is blank, remove the problem file
 			// from the array of possible files
 			if text == "" {
+				fmt.Printf("warn: found an empty file in the exercises directory: %s\n", filePath)
 				numFiles--
 				if numFiles == 0 {
-					msg := "all files are empty?! crazy!"
+					msg := fmt.Sprintf("no exercises found in the following exercise directory: %s\n", exercisesDir)
 					err = errors.New(msg)
 					return
+				} else {
+					fmt.Println("trying another exercise file...")
 				}
 				files = append(files[:randI], files[randI+1:]...)
 			}

--- a/cmd/root/sweet_test.go
+++ b/cmd/root/sweet_test.go
@@ -449,9 +449,15 @@ func TestFromArgsWithEmptyExerciseFiles(t *testing.T) {
 			args: []string{},
 			check: func(got Exercise, gotErr error) {
 				name := "multiple blank exercise files when randomly selecting, should exit if there are no remaining files"
+				dir := os.Getenv("SWEET_EXERCISES_DIR")
+				wantErrMsg := fmt.Sprintf("no exercises found in the following exercise directory: %s\n", dir)
 				if gotErr == nil {
 					t.Fatalf("%s wanted error, got nil\n", name)
 				}
+				if gotErr.Error() != wantErrMsg {
+					t.Fatalf("got error msg:\n\t%s\nwanted error msg\n\t%s", gotErr.Error(), wantErrMsg)
+				}
+
 			},
 		},
 		{
@@ -459,8 +465,13 @@ func TestFromArgsWithEmptyExerciseFiles(t *testing.T) {
 			args:          []string{},
 			check: func(got Exercise, gotErr error) {
 				name := "no exercise files, should error"
+				dir := os.Getenv("SWEET_EXERCISES_DIR")
+				wantErrMsg := fmt.Sprintf("no exercises found in the following exercise directory: %s\n", dir)
 				if gotErr == nil {
 					t.Fatalf("%s wanted error, got nil\n", name)
+				}
+				if gotErr.Error() != wantErrMsg {
+					t.Fatalf("got error msg:\n\t%s\nwanted error msg\n\t%s", gotErr.Error(), wantErrMsg)
 				}
 			},
 		},


### PR DESCRIPTION
Fixes #30

If there are no exercise files in the exercises directory, error with a helpful message. Likewise, if there are files, but they are all empty, error with a helpful message.

If there's a mix of files that are empty and not empty, skip empty files until you find a file that has content. If none can be found, error with a helpful message.

Also, wrote the tests to support these cases.
