### PR TITLE
Hide most missed characters when there are no mistakes.

### DIFF
--- a/cmd/root/results.go
+++ b/cmd/root/results.go
@@ -251,13 +251,16 @@ func mostMissedKeys(events []event) string {
 }
 
 func showResults(m exerciseModel) {
+	mistakes := numMistakes(m.events)
 	fmt.Printf("results of %s:\n", m.exercise.name)
 	fmt.Printf("wpm:                 %.f\n", wpm(m.events))
 	fmt.Printf("uncorrected errors:  %d\n", numUncorrectedErrors(m.events))
 	fmt.Printf("duration:            %s\n", duration(m.events))
 	fmt.Printf("mistakes:            %d\n", numMistakes(m.events))
 	fmt.Printf("accuracy:            %s%%\n", accuracy(m.events))
-	fmt.Printf("most missed keys:    %s\n", mostMissedKeys(m.events))
+	if mistakes > 0 {
+		fmt.Printf("most missed keys:    %s\n", mostMissedKeys(m.events))
+	}
 	fmt.Printf("graph:\n%s", wpmGraph(m.events))
 	fmt.Println()
 }

--- a/cmd/root/results_test.go
+++ b/cmd/root/results_test.go
@@ -438,6 +438,20 @@ func TestMostMissedKeys(t *testing.T) {
 			events: []event{},
 			want:   "",
 		},
+		{
+			name: "no mistakes",
+			events: parseEvents(
+				"2024-10-07 16:29:26.916\t0\tc\tc\n" +
+					"2024-10-07 16:29:27.004\t1\to\to\n" +
+					"2024-10-07 16:29:27.095\t2\tn\tn\n" +
+					"2024-10-07 16:29:27.279\t3\ts\ts\n" +
+					"2024-10-07 16:29:27.416\t4\to\to\n" +
+					"2024-10-07 16:29:27.667\t5\tl\tl\n" +
+					"2024-10-07 16:29:27.784\t6\te\te\n" +
+					"2024-10-07 16:29:31.538\t7\tenter\tenter",
+			),
+			want: "",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Output if there's a mistake
```sh
❯  echo "whats up" | ./sweet -
results of stdin:
wpm:                 54
uncorrected errors:  0
duration:            2.203770009s
mistakes:            1
accuracy:            90.00%
most missed keys:    s (1 time)
graph:
 60 ┼╮
 54 ┤╭╮
 48 ┤││
 42 ┤│╰
 36 ┤││
 30 ┤││
 24 ┤││
 18 ┤││
 12 ┤││
  6 ┤││
  0 ┼╯╰

     ■ raw wpm   ■ wpm
```

Output if there isn't a mistake
```sh
❯  echo "whats up" | ./sweet -
results of stdin:
wpm:                 93
uncorrected errors:  0
duration:            1.16496156s
mistakes:            0
accuracy:            100.00%
graph:
 96 ┼╮
 86 ┤│
 77 ┤│
 67 ┤│
 58 ┤╰
 48 ┤│
 38 ┤│
 29 ┤│
 19 ┤│
 10 ┤│
  0 ┤╰

     ■ raw wpm   ■ wpm
```
