### PR TITLE
Fix the colors of typed characters and the cursor in the typing game.

### DIFF
--- a/cmd/root/sweet.go
+++ b/cmd/root/sweet.go
@@ -409,11 +409,11 @@ func (m exerciseModel) exerciseNameView() string {
 
 func (m exerciseModel) exerciseTextView() (s string) {
 	// typed style
-	ts := lg.NewStyle().Foreground(lg.Color("#FFFFFF"))
+	ts := lg.NewStyle()
 	// untyped style
 	us := lg.NewStyle().Foreground(lg.Color("7"))
 	// cursor style
-	cs := lg.NewStyle().Background(lg.Color("255")).Foreground(lg.Color("0"))
+	cs := lg.NewStyle().Background(lg.Color("15")).Foreground(lg.Color("0"))
 	// incorrest style
 	is := lg.NewStyle().Background(lg.Color("1")).Foreground(lg.Color("15"))
 


### PR DESCRIPTION
<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/61dd7128-77f8-49aa-a2d2-73a9b5ab5925)
</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/3076c8ae-b170-4d3f-91e2-b22575fe26aa)

![image](https://github.com/user-attachments/assets/860dab49-ca5f-433b-ab83-944c8d23bc34)

</details>
